### PR TITLE
fix(#63): update KDE Connect clipboard activity path

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,8 +11,8 @@ android {
         applicationId "com.smoothie.wirelessDebuggingSwitch"
         targetSdk 34
         minSdk 30
-        versionCode 4
-        versionName "1.3"
+        versionCode 5
+        versionName "1.3.1"
     }
 
     buildFeatures {

--- a/app/src/main/java/com/smoothie/wirelessDebuggingSwitch/KdeConnect.kt
+++ b/app/src/main/java/com/smoothie/wirelessDebuggingSwitch/KdeConnect.kt
@@ -8,7 +8,7 @@ object KdeConnect {
 
     private const val PACKAGE_NAME = "org.kde.kdeconnect_tp"
     private const val CLIPBOARD_ACTIVITY_NAME =
-        "org.kde.kdeconnect.Plugins.ClibpoardPlugin.ClipboardFloatingActivity"
+        "org.kde.kdeconnect.Plugins.ClipboardPlugin.ClipboardFloatingActivity"
 
     fun isInstalled(context: Context): Boolean {
         val kdeConnectInstalled = isPackageInstalled(context, PACKAGE_NAME)
@@ -22,7 +22,7 @@ object KdeConnect {
     /**
      * Synchronizes the clipboard data using KDE Connect.
      * Requires root access. Starts
-     * [the following activity](https://invent.kde.org/network/kdeconnect-android/-/blob/aca039433c455b44b621dda077b940f26a732f25/src/org/kde/kdeconnect/Plugins/ClibpoardPlugin/ClipboardFloatingActivity.java)
+     * [the following activity](https://invent.kde.org/network/kdeconnect-android/-/blob/aca039433c455b44b621dda077b940f26a732f25/src/org/kde/kdeconnect/Plugins/ClipboardPlugin/ClipboardFloatingActivity.java)
      * of KDE Connect.
      */
     fun sendClipboard(): Shell.Result {

--- a/app/src/main/java/com/smoothie/wirelessDebuggingSwitch/KdeConnect.kt
+++ b/app/src/main/java/com/smoothie/wirelessDebuggingSwitch/KdeConnect.kt
@@ -8,7 +8,7 @@ object KdeConnect {
 
     private const val PACKAGE_NAME = "org.kde.kdeconnect_tp"
     private const val CLIPBOARD_ACTIVITY_NAME =
-        "org.kde.kdeconnect.Plugins.ClipboardPlugin.ClipboardFloatingActivity"
+        "org.kde.kdeconnect.plugins.clipboard.ClipboardFloatingActivity"
 
     fun isInstalled(context: Context): Boolean {
         val kdeConnectInstalled = isPackageInstalled(context, PACKAGE_NAME)
@@ -22,7 +22,7 @@ object KdeConnect {
     /**
      * Synchronizes the clipboard data using KDE Connect.
      * Requires root access. Starts
-     * [the following activity](https://invent.kde.org/network/kdeconnect-android/-/blob/aca039433c455b44b621dda077b940f26a732f25/src/org/kde/kdeconnect/Plugins/ClipboardPlugin/ClipboardFloatingActivity.java)
+     * [the following activity](https://invent.kde.org/network/kdeconnect-android/-/blob/master/src/main/java/org/kde/kdeconnect/plugins/clipboard/ClipboardFloatingActivity.java)
      * of KDE Connect.
      */
     fun sendClipboard(): Shell.Result {


### PR DESCRIPTION
## Summary

Quick timeline of what happened with the clipboard sync path:

WADBS used `Plugins.ClibpoardPlugin` which matched KDE Connect's own naming at the time (the typo was on their side). KDE Connect fixed the typo to `ClipboardPlugin` in late 2025 ([KDE Bug 508335](https://bugs.kde.org/show_bug.cgi?id=508335)), which broke WADBS ([#63](https://github.com/Smooth-E/wireless-adb-switch/issues/63)). Then on Jan 24 2026 KDE Connect landed [`70452ce6`](https://github.com/KDE/kdeconnect-android/commit/70452ce6ff2b112c336394ee7320525fc3827ee8) renaming all packages to lowercase (219 files changed). KDE Connect v1.35.1 shipped with the new structure.

This updates the activity path to `plugins.clipboard.ClipboardFloatingActivity` to match KDE Connect >= 1.35.1. Users on older KDE Connect versions will break but this is the correct canonical naming going forward.

A patched build is available at [hxreborn/wireless-adb-switch v1.3.1](https://github.com/hxreborn/wireless-adb-switch/releases/tag/v1.3.1) (different signing key, requires uninstall first).

Fixes #63

## Tested on

KDE Connect 1.35.1 (F-Droid), WADBS debug build, rooted device. Clipboard sync works, no more `result code=-92` in logcat.